### PR TITLE
update readme for preboot

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,8 @@
 # angular2-webpack
-A complete, yet simple, starter for Angular 2 using webpack 2
 
-Inspired by [Angular2 Webpack Starter](https://github.com/AngularClass/angular2-webpack-starter) & [Angular 1 Webpack workflow](https://github.com/Foxandxss/angular-webpack-workflow).
+A complete, yet simple, starter for Angular 2 using webpack 2.
 
-
-This seed repo serves as an Angular 2 starter for anyone looking to get up and running with Angular 2 and TypeScript fast. Using a [Webpack](http://webpack.github.io/) for building our files and assisting with boilerplate. We're also using Protractor for our end-to-end story and Karma for our unit tests.
+This seed repo serves as an Angular 2 starter for anyone looking to get up and running with Angular 2 and TypeScript fast. Using [Webpack](http://webpack.github.io/) for building our files and assisting with boilerplate. We're also using Protractor for our end-to-end story and Karma for our unit tests.
 * Best practices in file and application organization for [Angular 2](https://angular.io/).
 * Ready to go build system using [Webpack](https://webpack.github.io/docs/) for working with [TypeScript](http://www.typescriptlang.org/).
 * Easily add new components using [Angular 2 cli](https://github.com/angular/angular-cli).
@@ -15,31 +13,31 @@ This seed repo serves as an Angular 2 starter for anyone looking to get up and r
 * Error reported with [TSLint](http://palantir.github.io/tslint/).
 * Documentation with [TypeDoc](http://typedoc.io/).
 
+>Warning: Make sure you're using the latest version of Node.js and NPM
 
-```coffeescript
-Warning: Make sure you're using the latest version of Node.js and NPM
-```
 [Is Angular 2 Ready Yet?](http://splintercode.github.io/is-angular-2-ready/)
 
 ### Quick start
+
 > Clone/Download the repo then edit `app.ts` inside [`/src/app/app.ts`](/src/app/app.ts)
 
 ```bash
 # clone our repo
-git clone https://github.com/preboot/angular2-webpack.git
+$ git clone https://github.com/preboot/angular2-webpack.git
 
 # change directory to our repo
-cd angular2-webpack
+$ cd angular2-webpack
 
 # install the repo with npm
-npm install
+$ npm install
 
 # start the server
-npm start
+$ npm start
 ```
 go to [http://localhost:3000](http://localhost:3000) in your browser
 
 # Table of Contents
+
 * [Getting Started](#getting-started)
     * [Dependencies](#dependencies)
     * [Installing](#installing)
@@ -55,17 +53,21 @@ go to [http://localhost:3000](http://localhost:3000) in your browser
 * [License](#license)
 
 # Getting Started
+
 ## Dependencies
+
 What you need to run this app:
-* `node` and `npm` (`brew install node`)
-* Ensure you're running the latest versions Node (`v4.1.x`+) and NPM (`2.14.x`+)
+* `node` and `npm` (Use [NVM](https://github.com/creationix/nvm))
+* Ensure you're running Node (`v4.1.x`+) and NPM (`2.14.x`+)
 
 ## Installing
+
 * `fork` this repo
 * `clone` your fork
 * `npm install` to install all dependencies
 
 ## Running the app
+
 After you have installed all dependencies you can now run the app with:
 ```bash
 npm start
@@ -77,10 +79,13 @@ It will start a local server using `webpack-dev-server` which will watch, build 
 ## Developing
 
 ### Add new components, services, pipes with Angular 2 cli
+
 * `npm install -g angular-cli` to install Angular 2 cli
 * Add a new component with: `ng generate component my-new-component`
 * Add a new service with: `ng generate service my-new-service`
 * Add a new pipe with: `ng generate pipe my-new-pipe`
+
+Read more at [angular-cli github](https://github.com/angular/angular-cli).
 
 ### Build files
 
@@ -121,27 +126,32 @@ It's simple, just install the lib via npm and import it in your code when you ne
 ### How to include external css files such as bootstrap.css ?
 
 Just install the lib and import the css files in [vendor.ts](https://github.com/preboot/angular2-webpack/blob/master/src/vendor.ts). For example this is how to do it with bootstrap:
+
 ```sh
 npm install bootstrap@4.0.0 --save
 ```
 
 And in [vendor.ts](https://github.com/preboot/angular2-webpack/blob/master/src/vendor.ts) add the following:
+
 ```ts
 import 'bootstrap/dist/css/bootstrap.css';
 ```
 
 
 # TypeScript
+
 > To take full advantage of TypeScript with autocomplete you would have to install it globally and use an editor with the correct TypeScript plugins.
 
 ## Use latest TypeScript compiler
+
 TypeScript 1.7.x includes everything you need. Make sure to upgrade, even if you installed TypeScript previously.
 
-```
+```bash
 npm install --global typescript
 ```
 
 ## Use a TypeScript-aware editor
+
 We have good experience using these editors:
 
 * [Visual Studio Code](https://code.visualstudio.com/)
@@ -153,18 +163,19 @@ We have good experience using these editors:
 
 **Please follow these basic steps to simplify pull request reviews:**
 
-* Please rebase your branch against the current master
-* Run ```npm install``` to make sure your development dependencies are up-to-date
-* Please ensure that the test suite passes ```npm test``` before submitting a PR
-* If you've added new functionality, **please** include tests which validate its behavior
-* Make reference to possible [issues](https://github.com/preboot/angular2-webpack/issues) on PR comment
+* Please rebase your branch against the current master.
+* Run `npm install` to make sure your development dependencies are up-to-date.
+* Please ensure that the test suite passes `npm test` before submitting a PR.
+* If you've added new functionality, **please** include tests which validate its behavior.
+* Make reference to possible [issues](https://github.com/preboot/angular2-webpack/issues) on PR comment.
 
 ### Submitting bug reports
 
-* Please detail the affected browser(s) and operating system(s)
-* Please be sure to state which version of node **and** npm you're using
+* Please detail the affected browser(s) and operating system(s).
+* Please be sure to state which version of node **and** npm you're using.
 
 # Other Seed/Example Repos
+
 * [angular2-webpack-starter (AngularClass)](https://github.com/angularclass/angular2-webpack-starter)
   * Client/Server, Webpack, TypeScript, TSD, Protractor, Karma, Jasmine
 * [ng2-play (Pawel Kozlowski)](https://github.com/pkozlowski-opensource/ng2-play)


### PR DESCRIPTION
Pretty much spacing (won't be seen on github, but flows better on the raw).

Changes I made:

I removed the "Inspired" part. I think that is nice for a new starter, but not when it is more used. One of them is the angular-webpack and since it is now under the same org, doesn't make much sense.

Swapped brew for NVM (much much better this days where you need v4.x.x for something and v5.x.x for other stuff. Also removed the "latest version" since 4.x is not latest anymore.

Added a link to angular-cli so the user can read more.

