### PR TITLE
revert to webpack 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Dependency Status](https://david-dm.org/preboot/angular2-webpack/status.svg)](https://david-dm.org/preboot/angular2-webpack#info=dependencies) [![devDependency Status](https://david-dm.org/preboot/angular2-webpack/dev-status.svg)](https://david-dm.org/preboot/angular2-webpack#info=devDependencies)
 
-A complete, yet simple, starter for Angular 2 using webpack 2.
+A complete, yet simple, starter for Angular 2 using Webpack.
 
 This seed repo serves as an Angular 2 starter for anyone looking to get up and running with Angular 2 and TypeScript fast. Using [Webpack](http://webpack.github.io/) for building our files and assisting with boilerplate. We're also using Protractor for our end-to-end story and Karma for our unit tests.
 * Best practices in file and application organization for [Angular 2](https://angular.io/).

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,5 +1,5 @@
 var path = require('path');
-var webpackConfig = require('./webpack.config')('test');
+var webpackConfig = require('./webpack.config');
 
 module.exports = function(config) {
     var _config = {

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "clean-install": "npm run clean && npm install",
     "clean-start": "npm run clean && npm start",
     "watch": "webpack --watch --progress --profile",
-    "build": "rimraf dist && webpack --env prod --progress --profile",
-    "server": "webpack-dev-server --env dev --inline --progress --port 3000",
+    "build": "rimraf dist && webpack --progress --profile",
+    "server": "webpack-dev-server --inline --progress --port 3000",
     "webdriver-update": "webdriver-manager update",
     "webdriver-start": "webdriver-manager start",
     "lint": "tsconfig-lint",
@@ -65,7 +65,7 @@
     "typescript": "^1.7.3",
     "typings": "^0.6.8",
     "url-loader": "^0.5.6",
-    "webpack": "^2.0.7-beta",
-    "webpack-dev-server": "^2.0.0-beta"
+    "webpack": "^1.12.13",
+    "webpack-dev-server": "^1.14.1"
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,7 +9,13 @@ var HtmlWebpackPlugin = require('html-webpack-plugin');
 var ExtractTextPlugin = require('extract-text-webpack-plugin');
 var CopyWebpackPlugin = require('copy-webpack-plugin');
 
-module.exports = function makeWebpackConfig(ENV) {
+/**
+ * Env
+ * Get npm lifecycle event to identify the environment
+ */
+var ENV = process.env.npm_lifecycle_event;
+
+module.exports = function makeWebpackConfig() {
     /**
      * Config
      * Reference: http://webpack.github.io/docs/configuration.html
@@ -24,14 +30,14 @@ module.exports = function makeWebpackConfig(ENV) {
      */
     if(ENV === 'test') {
         config.devtool = 'inline-source-map';
-    } else if(ENV === 'prod') {
+    } else if(ENV === 'build') {
         config.devtool = 'source-map';
     } else {
         config.devtool = 'eval-source-map';
     }
 
     // add debug messages
-    config.debug = ENV !== 'prod' || ENV !== 'test';
+    config.debug = ENV !== 'build' || ENV !== 'test';
 
     /**
      * Entry
@@ -50,7 +56,7 @@ module.exports = function makeWebpackConfig(ENV) {
         path: root('dist'),
         publicPath: '/',
         filename: 'js/[name].js',
-        chunkFilename: ENV === 'prod' ? '[id].chunk.js?[hash]' : '[id].chunk.js'
+        chunkFilename: ENV === 'build' ? '[id].chunk.js?[hash]' : '[id].chunk.js'
     };
 
     /**
@@ -202,12 +208,12 @@ module.exports = function makeWebpackConfig(ENV) {
             // Extract css files
             // Reference: https://github.com/webpack/extract-text-webpack-plugin
             // Disabled when in test mode or not in build mode
-            new ExtractTextPlugin('css/[name].css', {disable: ENV !== 'prod'})
+            new ExtractTextPlugin('css/[name].css', {disable: ENV !== 'build'})
         );
     }
 
     // Add build specific plugins
-    if(ENV === 'prod') {
+    if(ENV === 'build') {
         config.plugins.push(
             // Reference: http://webpack.github.io/docs/list-of-plugins.html#noerrorsplugin
             // Only emit files when there are no errors
@@ -273,7 +279,7 @@ module.exports = function makeWebpackConfig(ENV) {
     };
 
     return config;
-};
+}();
 
 // Helper functions
 function root(args) {


### PR DESCRIPTION
So basically the changes are to take advantage of npm_lifecycle_event as the event. I can put the ENV var inside the function or outside, don't care that much.

Now you can't export a function, just an object, so I need to call the function at the end.

On the other hand a simple `karma start` won't work now because won't pass the `test` env. Not a big deal.

Fixes #26 
Fixes #27