### PR TITLE
Fix tslint rule

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -17,7 +17,7 @@
     "no-duplicate-variable": true,
     "no-empty": true,
     "no-eval": true,
-    "no-trailing-comma": true,
+    "trailing-comma": false,
     "no-trailing-whitespace": true,
     "no-unused-expression": true,
     "no-unused-variable": true,


### PR DESCRIPTION
npm start reports error because of "wrong" tslint rule

`"no-trailing-comma"` -> [`trailing-comma`](http://palantir.github.io/tslint/rules/trailing-comma/)


![snapshot1](https://cloud.githubusercontent.com/assets/283690/13195300/17f99cb6-d7af-11e5-9055-a812148498b8.png)
