### PR TITLE
webpack stats presets

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -31,7 +31,7 @@ module.exports = function (config) {
     webpackMiddleware: {
       // webpack-dev-middleware configuration
       // i. e.
-      noInfo: true
+      stats: 'errors-only'
     },
 
     coverageReporter: {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -274,8 +274,9 @@ module.exports = function makeWebpackConfig() {
    * Reference: http://webpack.github.io/docs/webpack-dev-server.html
    */
   config.devServer = {
+    contentBase: './src/public',
     historyApiFallback: true,
-    contentBase: './src/public'
+    stats: 'minimal' // none (or false), errors-only, minimal, normal (or true) and verbose
   };
 
   return config;


### PR DESCRIPTION
Makes "npm start" stats less verbose. I apploed the stats presets to karma for consistency.

Its not yet documented (https://github.com/webpack/webpack/issues/1660) so I pasted level names as comment.