### PR TITLE
remove i18n folder

### DIFF
--- a/src/public/i18n/en.json
+++ b/src/public/i18n/en.json
@@ -1,3 +1,0 @@
-{
-  "HELLO": "Hello"
-}

--- a/src/public/i18n/fr.json
+++ b/src/public/i18n/fr.json
@@ -1,3 +1,0 @@
-{
-  "HELLO": "Bonjour"
-}


### PR DESCRIPTION
This is a bit of personal opinion, but since we removed ng2-translate, I think this should go away.

I even want to get rid of src/public if I manage to make html-loader work nice.