### PR TITLE
remove reference tag in bootstrap

### DIFF
--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -1,5 +1,3 @@
-/// <reference path="../typings/main.d.ts"/>
-
 import {enableProdMode, provide} from "angular2/core";
 import {bootstrap, ELEMENT_PROBE_PROVIDERS} from 'angular2/platform/browser';
 import {ROUTER_PROVIDERS, HashLocationStrategy, LocationStrategy} from 'angular2/router';


### PR DESCRIPTION
Playing with something else I realized that all modern editors / IDEs are able to read the `typings` folder so just by adding typings you remove all the errors. Also for some reason the compiler won't complain either (so it is reading the typings somehow).

So this can go away it seems.