### PR TITLE
Fixed typing file collisions

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,9 @@
     "moduleResolution": "node"
   },
   "exclude": [
-    "node_modules"
+    "node_modules",
+    "typings/main",
+    "typings/main.d.ts"
   ],
   "compileOnSave": false,
   "buildOnSave": false


### PR DESCRIPTION
This fixed typescript compiler errors in some IDEs (e.g. VS).  
See: https://angular.io/docs/ts/latest/guide/typescript-configuration.html