### PR TITLE
chore: use angular2-polyfill directly on script tag

### DIFF
--- a/src/public/index.html
+++ b/src/public/index.html
@@ -9,5 +9,8 @@
   </head>
   <body>
     <app>Loading...</app>
+    
+  <!-- Angular 2 requires this file to be loaded before anything else -->
+  <script src="polyfills/angular2-polyfills.js"></script>
   </body>
 </html>

--- a/src/vendor.ts
+++ b/src/vendor.ts
@@ -3,7 +3,6 @@
 import 'es6-shim/es6-shim.js';
 // todo remove once https://github.com/angular/angular/issues/6501 is fixed.
 import './shims/shims_for_IE.js';
-import 'angular2/bundles/angular2-polyfills.js';
 
 // Angular 2
 import 'angular2/platform/browser';

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -209,7 +209,15 @@ module.exports = function makeWebpackConfig() {
       // Extract css files
       // Reference: https://github.com/webpack/extract-text-webpack-plugin
       // Disabled when in test mode or not in build mode
-      new ExtractTextPlugin('css/[name].[hash].css', {disable: !isProd})
+      new ExtractTextPlugin('css/[name].[hash].css', {disable: !isProd}),
+      
+      // Copy angular2-polyfills to the output
+      // Reference: https://github.com/angular/angular/blob/master/modules/angular2/docs/bundles/overview.md
+      // Reference: https://github.com/kevlened/copy-webpack-plugin
+      new CopyWebpackPlugin([{
+        from: root('node_modules/angular2/bundles/angular2-polyfills.js'),
+        to: 'polyfills/'
+      }])
     );
   }
 


### PR DESCRIPTION
The official word on the polyfill is to load it before anything else is involved so we can be sure that all our app instances are inside a zone.

This could be potentially different in the future, but for now, this is the recommended way.

The major drawback I have now is that we cannot cache-bust the file because the Copy plugin doesn't have those niceties (and we would need to know the name before hand).

Another good thing would have have the html plugin to add the polyfill tag automatically.