### PR TITLE
fix: enableProdMode working again

### DIFF
--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -5,7 +5,7 @@ import {HTTP_PROVIDERS} from 'angular2/http';
 
 const ENV_PROVIDERS = [];
 // depending on the env mode, enable prod mode or add debugging modules
-if (process.env.ENV === 'prod') {
+if (process.env.ENV === 'build') {
   enableProdMode();
 } else {
   ENV_PROVIDERS.push(ELEMENT_PROBE_PROVIDERS);


### PR DESCRIPTION
I broke it when I changed back to webpack 1. Not the best solution but better than having to rename environments.

Seems like the issues we had on webpack 2 are resolved (I would need to try).