### PR TITLE
simplify HtmlWebpackPlugin options

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -177,8 +177,7 @@ module.exports = function makeWebpackConfig() {
       // Reference: https://github.com/ampedandwired/html-webpack-plugin
       new HtmlWebpackPlugin({
         template: './src/public/index.html',
-        inject: 'body',
-        chunksSortMode: packageSort(['polyfills', 'vendor', 'app'])
+        chunksSortMode: 'dependency'
       }),
 
       // Extract css files


### PR DESCRIPTION
1. `inject: 'body'` is default
2. `chunksSortMode: 'dependency'` should sort your injects correctly, without helper function, also will be the default behavior in webpack2