### PR TITLE
make pretest lint windows friendly

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "server": "webpack-dev-server --inline --progress --port 8080",
     "webdriver-update": "webdriver-manager update",
     "webdriver-start": "webdriver-manager start",
-    "lint": "tslint 'src/**/*.ts'; exit 0",
+    "lint": "tslint \"src/**/*.ts\"",
     "e2e": "protractor",
     "e2e-live": "protractor --elementExplorer",
     "pretest": "npm run lint",


### PR DESCRIPTION
tslint pretest always errored out for me in my Windows environment.
```
C:\devel\repos\preboot_seed\node_modules\tslint\node_modules\glob\sync.js:29
    throw new Error('must provide pattern')
    ^
```
The main thing was the single quotes, vs escaped double quotes for Windows.

I wasn't able to determine the purpose of the `; exit 0` either... which also caused tslint to throw the same error.