### PR TITLE
Cross-platform tslint successful exit status and glob quoting.

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "server": "webpack-dev-server --inline --progress --port 8080",
     "webdriver-update": "webdriver-manager update",
     "webdriver-start": "webdriver-manager start",
-    "lint": "tslint 'src/**/*.ts'; exit 0",
+    "lint": "tslint --force \"src/**/*.ts\"",
     "e2e": "protractor",
     "e2e-live": "protractor --elementExplorer",
     "pretest": "npm run lint",


### PR DESCRIPTION
Windows was struggling with the semicolon-separated exit 0. Windows also only begins traversing the right files when the glob is double-quoted.