### PR TITLE
Added expectation to AboutComponent test

### DIFF
--- a/src/app/about/about.component.spec.ts
+++ b/src/app/about/about.component.spec.ts
@@ -13,10 +13,13 @@ describe('About Component', () => {
     addProviders([]);
   });
 
-  it('should ...', async(inject([TestComponentBuilder], (tcb: TestComponentBuilder) => {
-    tcb.createAsync(AboutComponent).then((fixture) => {
-      fixture.detectChanges();
-    });
+  it('template should contain <p> with "About Works!" text',
+    async(inject([TestComponentBuilder], (tcb: TestComponentBuilder) => {
+      tcb.createAsync(AboutComponent).then((fixture) => {
+        fixture.detectChanges();
+        let compiled = fixture.debugElement.nativeElement;
+        expect(compiled.querySelector('p').textContent.toString().trim()).toEqual('About Works!');
+      });
   })));
 
 });


### PR DESCRIPTION
There was no expect() or other test verification in the test inside about.component.spec.ts. This PR adds an expectation to that test.