### PR TITLE
webpack : fixed issue for get parameters (used in font awesome notably)

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -92,7 +92,10 @@ module.exports = function makeWebpackConfig() {
       },
 
       // copy those assets to output
-      {test: /\.(png|jpe?g|gif|svg|woff|woff2|ttf|eot|ico)$/, loader: 'file?name=fonts/[name].[hash].[ext]?'},
+      {
+        test: /\.(png|jpe?g|gif|svg|woff|woff2|ttf|eot|ico)(\?v=[0-9]\.[0-9]\.[0-9])?$/,
+        loader: 'file?name=fonts/[name].[hash].[ext]?'
+      },
 
       // Support for *.json files.
       {test: /\.json$/, loader: 'json'},


### PR DESCRIPTION
Regarding issue #112 

Added the possibility to have GET parameters while loading static assets. This is used notably in Font Awesome library.