### PR TITLE
docs: correct comment

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,4 +1,4 @@
-// Helper: root(), and rootDir() are defined at the bottom
+// Helper: root() is defined at the bottom
 var path = require('path');
 var webpack = require('webpack');
 


### PR DESCRIPTION
Remove `rootDir()` out of top comment since we only have root() helper function