### PR TITLE
adds es6-shim to dev deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "codelyzer": "0.0.26",
     "copy-webpack-plugin": "^3.0.0",
     "css-loader": "^0.23.0",
+    "es6-shim": "^0.35.1",
     "extract-text-webpack-plugin": "^1.0.1",
     "file-loader": "^0.9.0",
     "html-loader": "^0.4.0",


### PR DESCRIPTION
Running `npm test` gives errors because `karma-shim.js` is requiring `es6-shim` but not installed with `npm install`.