### PR TITLE
lock zone.js to 0.7.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "core-js": "^2.4.1",
     "reflect-metadata": "^0.1.3",
     "rxjs": "5.0.0-rc.4",
-    "zone.js": "^0.7.2"
+    "zone.js": "0.7.2"
   },
   "devDependencies": {
     "@angularclass/hmr": "^1.0.1",


### PR DESCRIPTION
0.7.3 seems to break, at least, the links