### PR TITLE
Set @types/lodash version explicitly avoid TS 2.1 errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@types/jasmine": "^2.2.29",
     "@types/node": "^6.0.38",
     "@types/selenium-webdriver": "2.53.33",
+    "@types/lodash": "4.14.50",
     "angular2-template-loader": "^0.6.0",
     "autoprefixer": "^6.3.2",
     "awesome-typescript-loader": "^3.0.0-beta.17",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,9 @@
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "sourceMap": true,
-    "noEmitHelpers": true
+    "noEmitHelpers": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true
   },
   "compileOnSave": false,
   "buildOnSave": false,


### PR DESCRIPTION
Essentially, a patch level semver update in @types/lodash (14.14.51) introduced TS 2.1 features, but we are using TS 2.0.10 until support for TS 2.1 officially lands for Angular. We need to lock it at version 14.14.50 for TS 2.0.x to not get errors.

More discussion and reference here: https://github.com/preboot/angular2-webpack/issues/283#issuecomment-276456247