### PR TITLE
Set TypeScript version 2.1.6 explicitly avoid Jasmine Errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "tslint": "^4.3.1",
     "tslint-loader": "^3.3.0",
     "typedoc": "^0.5.1",
-    "typescript": "2.0.10",
+    "typescript": "2.1.6",
     "url-loader": "^0.5.6",
     "webpack": "2.1.0-beta.25",
     "webpack-dev-server": "2.1.0-beta.9"


### PR DESCRIPTION
Errors before upgrading to new version,

TS1005: '=' expected.
TS2371: A parameter initializer is only allowed in a function or constructor implementation.
TS2304: Cannot find name 'keyof'.
From (unknown) [at-loader] node_modules/@types/jasmine/index.d.ts