### PR TITLE
Lock @types/jasmine version to avoid TS 2.1 errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@angularclass/hmr": "^1.0.1",
     "@angularclass/hmr-loader": "^3.0.2",
     "@types/core-js": "^0.9.0",
-    "@types/jasmine": "^2.2.29",
+    "@types/jasmine": "2.5.41",
     "@types/node": "^6.0.38",
     "@types/selenium-webdriver": "2.53.33",
     "@types/lodash": "4.14.50",


### PR DESCRIPTION
`@types/jasmine` introduced Typescript 2.1 features in `2.5.42`, this locks the version to `2.5.41` as we are using Typescript 2.0.10 with Angular 2.x.

Once Angular 4.x is released and we bump the version here, Typescript 2.1 will be supported, and this version lock can be removed.